### PR TITLE
OBO synonym and xref schemas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Added types/schemas for `obo_synonym` and `obo_xref` on Term responses
 
 ## [0.5.0] - 2023-07-27
 ### Changed

--- a/src/ols_py/schemas/responses.py
+++ b/src/ols_py/schemas/responses.py
@@ -27,11 +27,30 @@ class Link(BaseModel):
     href: HttpUrl
 
 
+# TODO: not sure which of these are optional
+class OboXref(BaseModel):
+    database: Optional[str] = None
+    id: Optional[str] = None
+    description: Optional[str] = None
+    url: Optional[str] = None
+
+
+class OboSynonym(BaseModel):
+    name: str
+    # TODO: can this be a fixed set, e.g. hasExactSynonym, hasRelatedSynonym?
+    scope: str
+    type: Optional[str] = None
+    xrefs: list[OboXref] = Field(default_factory=list)
+
+
 class Term(BaseModel):
     """
     Response returned by term endpoints
     """
 
+    # Haven't typed all attributes yet, so allow additional fields
+    #   for now
+    model_config = ConfigDict(extra="allow")
     iri: pydantic.AnyUrl
     label: str
     description: list[str]
@@ -39,6 +58,8 @@ class Term(BaseModel):
     #   are fixed
     annotation: dict[str, list[str]]
     synonyms: Optional[list[str]] = None
+    obo_xref: Optional[list[OboXref]] = None
+    obo_synonym: Optional[list[OboSynonym]] = None
     ontology_name: str
     ontology_prefix: str
     ontology_iri: pydantic.AnyUrl
@@ -52,7 +73,6 @@ class Term(BaseModel):
     obo_id: Optional[str] = None
     in_subset: Optional[Any] = None
     links: dict[str, Link] = Field(..., alias="_links")
-    model_config = ConfigDict(extra="allow")
 
 
 class ApiInfoLinks(BaseModel):

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -62,5 +62,3 @@ def test_search_fields():
     )
     # Result items have an extra id field
     assert result_item_fields - return_fields == {"id"}
-    # TODO: currently have to allow for "synonyms" from OLS4
-    assert return_fields - result_item_fields == {"synonyms"}


### PR DESCRIPTION
Add schemas for `obo_synonym` and `obo_xref` fields on `Term`.
